### PR TITLE
ADR-0005: Event Store

### DIFF
--- a/docs/dev/adr/0005-event-store.md
+++ b/docs/dev/adr/0005-event-store.md
@@ -1,0 +1,20 @@
+# ADR-0005: Event Store
+
+**Status**: Accepted <br>
+**Related**: ADR-0003 Database, ADR-0004 Schema Migrations
+
+## Context
+
+CALISTA requires an append-only event log accross aggregates.
+
+## Decision
+
+- **Storage**: Relational table `event_store`.
+- **Backends**: Postgres for runtime, SQLite for dev/CI.
+- **Format**: Payload/metdata as JSON (Postgres JSONB, SQLite TEXT).
+
+## Consequences
+
+- Leverages RDBMS ACID guarantees.
+- Simple and portable.
+- Must handle JSON differences across dialects

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,3 +77,4 @@ nav:
           - "ADR 0002: Content-Addressed File Store (CAS)": dev/adr/0002-cas-file-store.md
           - "ADR 0003: Database": dev/adr/0003-database.md
           - "ADR 0004: Schema Migrations": dev/adr/0004-schema-migrations.md
+          - "ADR 0005: Event Store": dev/adr/0005-event-store.md


### PR DESCRIPTION
# ADR-0005: Event Store

**Status**: Accepted <br>
**Related**: ADR-0003 Database, ADR-0004 Schema Migrations

## Context

CALISTA requires an append-only event log accross aggregates.

## Decision

- **Storage**: Relational table `event_store`.
- **Backends**: Postgres for runtime, SQLite for dev/CI.
- **Format**: Payload/metdata as JSON (Postgres JSONB, SQLite TEXT).

## Consequences

- Leverages RDBMS ACID guarantees.
- Simple and portable.
- Must handle JSON differences across dialects
