### PR TITLE
ADR-0006: Event Envelope

### DIFF
--- a/docs/dev/adr/0006-event-envelope.md
+++ b/docs/dev/adr/0006-event-envelope.md
@@ -1,0 +1,29 @@
+# ADR-0006: Event Envelope
+
+**Status**: Accepted <br>
+**Related**: ADR-0005 Event Store
+
+## Context
+
+Events must share a consistent persisted structure.
+
+## Decision
+
+Canonical envelope fields:
+
+- `global_seq`: Monotonic sequence number across all events.
+- `stream_id`: Aggregate identifier (e.g., session ID, frame ID).
+- `stream_type`: Aggregate type (e.g., Session, BiasFrame).
+- `version`: Aggregate-local version number, incremented per event.
+- `event_id`: Globally unique identifier (ULID).
+- `recorded_at`: Timestamp when event was persisted (UTC, RFC3339).
+- `payload` : Event data (domain-specific fields).
+- `metadata`: System metadata (user, process ID, correlation ID, etc.).
+
+## Consequences
+
+- Ensures reliable replay of system history.
+- Enables optimistic concurrency checks via `version`.
+- Provides clear ordering across streams via `global_seq`.
+- Separates domain concerns (`payload`) from system concerns (`metadata`).
+- Extensible: new metadata fields can be added without breaking existing events.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,3 +78,4 @@ nav:
           - "ADR 0003: Database": dev/adr/0003-database.md
           - "ADR 0004: Schema Migrations": dev/adr/0004-schema-migrations.md
           - "ADR 0005: Event Store": dev/adr/0005-event-store.md
+          - "ADR 0006: Event Envelope": dev/adr/0006-event-envelope.md


### PR DESCRIPTION
# ADR-0006: Event Envelope

**Status**: Accepted <br>
**Related**: ADR-0005 Event Store

## Context

Events must share a consistent persisted structure.

## Decision

Canonical envelope fields:

- `global_seq`: Monotonic sequence number across all events.
- `stream_id`: Aggregate identifier (e.g., session ID, frame ID).
- `stream_type`: Aggregate type (e.g., Session, BiasFrame).
- `version`: Aggregate-local version number, incremented per event.
- `event_id`: Globally unique identifier (ULID).
- `recorded_at`: Timestamp when event was persisted (UTC, RFC3339).
- `payload` : Event data (domain-specific fields).
- `metadata`: System metadata (user, process ID, correlation ID, etc.).

## Consequences

- Ensures reliable replay of system history.
- Enables optimistic concurrency checks via `version`.
- Provides clear ordering across streams via `global_seq`.
- Separates domain concerns (`payload`) from system concerns (`metadata`).
- Extensible: new metadata fields can be added without breaking existing events.
