### PR TITLE
ADR-0009: Timekeeping

### DIFF
--- a/docs/dev/adr/0009-timekeeping
+++ b/docs/dev/adr/0009-timekeeping
@@ -1,0 +1,17 @@
+# ADR-0009: Timekeeping
+
+**Status**: Accepted <br>
+**Related**: ADR-0006 Event Envelope
+
+## Context
+
+Events must have reliable timestamps.
+
+## Decision
+
+- Store `recorded_at` in UTC, RFC3339 format.
+
+## Consequences
+
+- Consistent ordering across environments.
+- No timezone drift issues.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,3 +81,4 @@ nav:
           - "ADR 0006: Event Envelope": dev/adr/0006-event-envelope.md
           - "ADR 0007: Identifiers (UUID vs ULID)": dev/adr/0007-identifiers.md
           - "ADR 0008: Concurrency & Versioning": dev/adr/0008-concurrency-and-versioning.md
+          - "ADR 0009: Timekeeping": dev/adr/0009-timekeeping.md


### PR DESCRIPTION
# ADR-0009: Timekeeping

**Status**: Accepted <br>
**Related**: ADR-0006 Event Envelope

## Context

Events must have reliable timestamps.

## Decision

- Store `recorded_at` in UTC, RFC3339 format.

## Consequences

- Consistent ordering across environments.
- No timezone drift issues.
