### PR TITLE
ADR-0011: File Store Integration

### DIFF
--- a/docs/dev/adr/0011-filestore-integration.md
+++ b/docs/dev/adr/0011-filestore-integration.md
@@ -1,0 +1,18 @@
+# ADR-0011: File Store Integration
+
+**Status**: Accepted <br>
+**Related**: ADR-0005 Event Store Schema, ADR-0006 Event Envelope
+
+## Context
+
+Large artifacts (FITS, calibrated images) must not bloat event store.
+
+## Decision
+
+- Store digest references (sha256) in events.
+- Actual files live in CALISTA’s content-addressable file store.
+
+## Consequences
+
+- Event store remains lean.
+- Provenance preserved by digest integrity.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,3 +83,4 @@ nav:
           - "ADR 0008: Concurrency & Versioning": dev/adr/0008-concurrency-and-versioning.md
           - "ADR 0009: Timekeeping": dev/adr/0009-timekeeping.md
           - "ADR 0010: Retention & Archival": dev/adr/0010-retention-and-archival.md
+          - "ADR 0011: File Store Integration": dev/adr/0011-filestore-integration.md


### PR DESCRIPTION
# ADR-0011: File Store Integration

**Status**: Accepted <br>
**Related**: ADR-0005 Event Store Schema, ADR-0006 Event Envelope

## Context

Large artifacts (FITS, calibrated images) must not bloat event store.

## Decision

- Store digest references (sha256) in events.
- Actual files live in CALISTA’s content-addressable file store.

## Consequences

- Event store remains lean.
- Provenance preserved by digest integrity.
