### PR TITLE
docs(dev): enhance tooling guide with detailed configuration sections

### DIFF
--- a/docs/dev/tooling.md
+++ b/docs/dev/tooling.md
@@ -1,17 +1,47 @@
-### Configuration Conventions
+# Tooling Guide
 
-We centralize tool configuration in `pyproject.toml` whenever possible, so settings are Git-tracked and colocated with other build metadata.
+This page describes how development tools are configured for CALISTA.
+
+## Configuration Conventions
+
+Tool configuration is centralized in `pyproject.toml` whenever possible, so settings are Git-tracked and colocated with build metadata.
 
 - **In `pyproject.toml`**
+    - `ruff` (linting + formatting)
+    - `mypy` (static typing)
+    - `pytest`
+    - `pyright` (used by Pylance)
+    - `mutmut` (mutation testing)
 
-  - `ruff` (linting + formatting)
-  - `mypy` (static typing)
-  - `pytest` (under `[tool.pytest.ini_options]`)
+- **Separate files**
+    - `.pylintrc` → Pylint rules
 
-- **Separate files (tool does not support `pyproject.toml`)**
-  - `.pylintrc` → Pylint rules
-  - `.editorconfig` → basic editor formatting hints (optional)
+Editor-only preferences (e.g. VS Code’s `settings.json`) are kept local and not committed.
 
-Other editor-only preferences (e.g. VS Code’s `settings.json`) are kept local and not committed.
+## Python Versions & Environments
 
-This split ensures reproducible tooling while respecting each tool’s supported config format.
+- Python version is declared in `pyproject.toml`.
+- Local installs managed with Poetry.
+- Virtual environments (`.venv/`, `venv/`) and dotenv files are not committed.
+
+## Pre-commit Hooks
+
+- `pre-commit` runs fast checks before commits (ruff, mypy, pytest).
+- Hooks are defined in `.pre-commit-config.yaml` and kept up to date with `pre-commit autoupdate`.
+
+## Testing
+
+- Pytest is the primary test runner.
+- Hypothesis is used for property-based testing and integrates directly with pytest.
+- Default discovery runs under `tests/`. Non-test folders like `scratch/` are ignored.
+- Mutation testing is performed with Mutmut.
+
+## Static Typing
+
+- Type checking is handled by Pyright (via Pylance in VS Code).
+- Configuration is kept in `pyproject.toml`.
+
+## CI Alignment
+
+- CI runs the same tooling (ruff, mypy, pytest, mutmut) using `pyproject.toml`.
+- Python version matrix matches the version declared locally.


### PR DESCRIPTION
### Why
Tool configuration in CALISTA is spread across pyproject.toml and a few separate files.
There was no single place in the docs that explained which tools are used, how they are
configured, and how they tie together locally and in CI. A dedicated tooling guide makes
it easier to understand the project’s development environment.

### What
- Expand `docs/dev/tooling.md`.
- Describe configuration conventions: which tools live in `pyproject.toml` vs separate files.
- Document testing stack: pytest, Hypothesis, Mutmut.
- Document typing (Pyright/Pylance), linting (ruff, mypy, pylint), and pre-commit hooks.
- Cover Python version management, virtual environments, and CI alignment.

### Impact
- Documentation only, no code or config changes.
- Provides a single reference for development tooling.
- Complements `docs/dev/testing.md` by focusing on project-wide tools and conventions.
