### PR TITLE
feat(cli): add `calista db status`

### DIFF
--- a/docs/user/install/database.md
+++ b/docs/user/install/database.md
@@ -16,16 +16,43 @@ CALISTA uses **PostgreSQL** by default.
     export CALISTA_DB_URL=postgresql+psycopg://calista@localhost:5432/calista
     ```
 
-2. Initialize the schema:
+2. Check database status:
+
+    Before applying migrations, verify CALISTA can reach your database:
+
+    ```bash
+    calista db status
+    ```
+
+    **Typical output**
+
+    _Uninitialized (fresh database):_
+
+    ```bash
+    ✅  Database reachable
+    Backend : postgresql
+    URL     : postgresql+psycopg://USER:***@localhost:5432/calista
+    Schema  : uninitialized
+    ```
+
+    If you see " Cannot connect to database", double-check `CALISTA_DB_URL` and that your DB is running.
+
+3. Initialize the schema:
 
     ```bash
     calista db upgrade
     ```
 
-3. (Optional) Verify the current revision:
+4. (Optional) Verify the current revision:
 
     ```bash
     calista db current
+    ```
+
+    or
+
+    ```bash
+    calista db status
     ```
 
 ## If you don’t already have a PostgreSQL database
@@ -79,26 +106,3 @@ calista db upgrade
 SQLite is supported for quick local runs and CI, but it lacks some PostgreSQL features (e.g., JSONB indexes, certain CHECK constraints).
 
 For more advanced database commands, see the [CLI reference](../cli/db.md).
-
----
-
-## CLI Reference — `calista db`
-
-The `calista db` command is a thin wrapper around Alembic migrations.
-It provides convenient subcommands for initializing and inspecting the CALISTA schema.
-
-Typical first-run usage:
-
-```bash
-calista db upgrade
-```
-
-This upgrades your database to the latest schema revision.
-
-Advanced users may also use:
-
-- `current` — show the current revision
-- `heads` — list head revisions
-- `history` — show migration history
-
-## Command reference

--- a/src/calista/cli/helpers/__init__.py
+++ b/src/calista/cli/helpers/__init__.py
@@ -7,6 +7,6 @@ stderr with emoji→ASCII fallbacks.
 
 from .db_url import sanitize_url
 from .hyperlinks import hyperlink
-from .messages import success, warn
+from .messages import error, success, warn
 
-__all__ = ["sanitize_url", "warn", "success", "hyperlink"]
+__all__ = ["sanitize_url", "warn", "success", "error", "hyperlink"]

--- a/src/calista/cli/helpers/messages.py
+++ b/src/calista/cli/helpers/messages.py
@@ -26,7 +26,7 @@ def _supports_character(character: str, stream: TextIO | None = None) -> bool:
     """
 
     stream = stream or click.get_text_stream("stderr")
-    encoding = getattr(stream, "encoding", None) or "utf-8"
+    encoding = getattr(stream, "encoding")
     try:
         character.encode(encoding)
     except UnicodeEncodeError:

--- a/src/calista/config.py
+++ b/src/calista/config.py
@@ -3,6 +3,7 @@
 This module centralizes small helpers and constants related to application configuration.
 """
 
+import os
 import sys
 from importlib.resources import files
 from pathlib import Path
@@ -16,7 +17,27 @@ ALEMBIC_URL_KEY = "sqlalchemy.url"  # pragma: no mutate
 ALEMBIC_SCRIPT_LOCATION_KEY = "script_location"  # pragma: no mutate
 
 
-def build_alembic_config(db_url: str, stdout: TextIO = sys.stdout) -> Config:
+class DatabaseUrlNotSetError(Exception):
+    """Raised when the CALISTA_DB_URL environment variable is not set."""
+
+
+def get_db_url() -> str:
+    """Get the database URL from the environment.
+
+    Returns:
+        The value of the `CALISTA_DB_URL` environment variable.
+
+    Raises:
+        DatabaseUrlNotSetError: If `CALISTA_DB_URL` is not set.
+    """
+    if not (url := os.environ.get("CALISTA_DB_URL")):
+        raise DatabaseUrlNotSetError
+    return url
+
+
+def build_alembic_config(
+    db_url: str | None = None, stdout: TextIO = sys.stdout
+) -> Config:
     """Build an Alembic `Config` object for CALISTA's migrations.
 
     Sets only Alembic "main" options:
@@ -25,7 +46,8 @@ def build_alembic_config(db_url: str, stdout: TextIO = sys.stdout) -> Config:
 
     Args:
         db_url: SQLAlchemy database URL (e.g., `sqlite:///:memory:` or
-            `postgresql+psycopg://user:pass@host/dbname`).
+            `postgresql+psycopg://user:pass@host/dbname`). Can be `None` (default)
+            only in contexts where Alembic won't need to connect to the DB.
         stdout: Text stream Alembic will write status lines to. Defaults to
             `sys.stdout`; override in tests to capture output.
 
@@ -33,7 +55,8 @@ def build_alembic_config(db_url: str, stdout: TextIO = sys.stdout) -> Config:
         An `alembic.config.Config` pointing to CALISTA's migration scripts.
     """
     cfg = Config(stdout=stdout)
-    cfg.set_main_option(ALEMBIC_URL_KEY, db_url)
+    if db_url is not None:
+        cfg.set_main_option(ALEMBIC_URL_KEY, db_url)
     cfg.set_main_option(
         ALEMBIC_SCRIPT_LOCATION_KEY,
         str(files("calista.infrastructure.db.alembic")),

--- a/tests/unit/cli_helpers/test_cli_helpers.py
+++ b/tests/unit/cli_helpers/test_cli_helpers.py
@@ -12,10 +12,9 @@ terminal by patching `click.get_text_stream` to return a stream object with
 
 from __future__ import annotations
 
-import click
 import pytest
 
-from calista.cli.helpers import hyperlinks, sanitize_url, success, warn
+from calista.cli.helpers import hyperlinks, sanitize_url
 
 # ---------------------------------------------------------------------------
 # Test utilities
@@ -125,31 +124,3 @@ def test_supports_osc8_non_tty(monkeypatch):
         )
         is False
     )
-
-
-# ---------------------------------------------------------------------------
-# Success / warning messages (emoji → ASCII fallback)
-# ---------------------------------------------------------------------------
-
-
-def test_warn_fallback(monkeypatch, capsys):
-    """When stderr is ASCII-only, `warn()` should use `[!]` instead of `⚠️`."""
-    # Patch the exact symbol helpers call so they "see" an ASCII stderr stream.
-    monkeypatch.setattr(click, "get_text_stream", lambda name: FakeAsciiStream())
-    warn("danger!")
-    out = capsys.readouterr().err
-    warn_emoji = "⚠️"
-    warn_fallback = "[!]"
-    assert warn_fallback in out
-    assert warn_emoji not in out
-
-
-def test_success_fallback(monkeypatch, capsys):
-    """When stderr is ASCII-only, `success()` should use `[OK]` (no emoji)."""
-    monkeypatch.setattr(click, "get_text_stream", lambda name: FakeAsciiStream())
-    success("all good")
-    out = capsys.readouterr().err
-    success_emoji = "✅"
-    success_fallback = "[OK]"
-    assert success_fallback in out
-    assert success_emoji not in out

--- a/tests/unit/cli_helpers/test_messages.py
+++ b/tests/unit/cli_helpers/test_messages.py
@@ -1,0 +1,156 @@
+"""Unit tests for :mod:`calista.cli.helpers.messages`.
+
+This suite verifies three behaviors:
+
+1) Emoji/ASCII glyph selection respects the *current* stderr encoding
+   reported by ``click.get_text_stream("stderr")``.
+2) ``_supports_character`` **re-queries** Click's text stream on every call
+   (guards against implementations that cache or ignore the stream).
+3) ``warn``/``success`` emit **styled** (ANSI yellow/green + bold + reset)
+   lines to **stderr** (and not stdout).
+"""
+
+import io
+import sys
+
+import click
+import pytest
+
+from calista.cli.helpers.messages import (
+    _supports_character,
+    caution_glyph,
+    error,
+    error_glyph,
+    success,
+    success_glyph,
+    warn,
+)
+
+SET_YELLOW = "\x1b[33m"
+SET_GREEN = "\x1b[32m"
+SET_RED = "\x1b[31m"
+SET_BOLD = "\x1b[1m"
+RESET = "\x1b[0m"
+
+
+class FakeTTY(io.StringIO):
+    """A text stream that mimics a TTY and exposes a controllable encoding.
+
+    Click consults the stream's ``.encoding`` and ``.isatty()`` to decide if
+    color should be emitted and whether Unicode glyphs are encodable. This
+    helper lets tests deterministically drive those decisions.
+    """
+
+    def __init__(self, encoding: str):
+        super().__init__()
+        self._encoding = encoding
+
+    @property
+    def encoding(self) -> str:
+        """Declared character encoding (e.g., ``'ascii'`` or ``'utf-8'``)."""
+        return self._encoding
+
+    @encoding.setter
+    def encoding(self, value: str) -> None:
+        self._encoding = value
+
+    def isatty(self) -> bool:
+        """Report that this stream is a TTY (prevents Click from stripping ANSI)."""
+        return True
+
+
+@pytest.mark.parametrize(
+    ("encoding", "expected_caution", "expected_success", "expected_error"),
+    [
+        ("ascii", "[!]", "[OK]", "[X]"),
+        ("utf-8", "⚠️", "✅", "❌"),
+    ],
+)
+def test_glyphs_respect_stream_encoding(
+    monkeypatch, encoding, expected_caution, expected_success, expected_error
+):
+    """caution_glyph/success_glyph/error_glyph choose emoji vs ASCII according to stderr encoding.
+
+    Patches ``click.get_text_stream("stderr")`` to a FakeTTY with the requested
+    encoding so the glyph decision is deterministic.
+    """
+    stream = FakeTTY(encoding)
+
+    # Force _supports_character() to inspect our fake stderr
+    monkeypatch.setattr(click, "get_text_stream", lambda name: stream)
+
+    assert caution_glyph() == expected_caution
+    assert success_glyph() == expected_success
+    assert error_glyph() == expected_error
+
+
+def test_supports_character_requeries_stream_each_call(monkeypatch):
+    """_supports_character must consult Click's stream on every call (no caching).
+
+    We alternate encodings between calls (ascii → utf-8) and expect the first
+    probe to fail and the second to succeed, proving re-querying behavior.
+    """
+    calls: list[str] = []
+
+    def stream_factory(name: str):  # pylint: disable=unused-argument
+        # Alternate encodings on each call
+        enc = "ascii" if len(calls) == 0 else "utf-8"
+        calls.append(enc)
+        return FakeTTY(enc)
+
+    monkeypatch.setattr(click, "get_text_stream", stream_factory)
+
+    # First call should report False for ascii (emoji not encodable)
+    assert _supports_character("⚠️") is False
+    # Second call should re-fetch and succeed for utf-8
+    assert _supports_character("⚠️") is True
+
+    assert calls == ["ascii", "utf-8"]  # sanity
+
+
+@pytest.mark.parametrize(
+    ("encoding", "glyph", "color_code", "func"),
+    [
+        ("ascii", "[!]", SET_YELLOW, warn),
+        ("utf-8", "⚠️", SET_YELLOW, warn),
+        ("ascii", "[OK]", SET_GREEN, success),
+        ("utf-8", "✅", SET_GREEN, success),
+        ("ascii", "[X]", SET_RED, error),
+        ("utf-8", "❌", SET_RED, error),
+    ],
+)
+def test_messages_emit_styled_stderr(monkeypatch, encoding, glyph, color_code, func):
+    """warn/success/error write bold, colored lines to stderr with the right glyph.
+
+    We point both the *probe* (Click's text stream) and the *writer* (sys.stderr)
+    to the same FakeTTY so that glyph choice and actual output are consistent.
+    """
+    stream = FakeTTY(encoding)
+
+    # Same object for probe and writer
+    monkeypatch.setattr(click, "get_text_stream", lambda name: stream)
+    monkeypatch.setattr(sys, "stderr", stream, raising=False)
+
+    # Ensure color is not globally disabled in CI
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("CLICOLOR", "1")
+
+    func("danger!")
+
+    out = stream.getvalue()
+    assert glyph in out
+    assert SET_BOLD in out
+    assert color_code in out
+    assert RESET in out
+
+
+def test_warn_writes_to_stderr_only(monkeypatch, capsys):
+    """warn should write to stderr and leave stdout untouched (for machine output)."""
+    stream = FakeTTY("utf-8")
+    monkeypatch.setattr(click, "get_text_stream", lambda name: stream)
+    # Let Click write to real sys.stderr so capsys can see it
+    msg = "danger!"
+    warn(msg)
+    captured = capsys.readouterr()
+    assert msg in captured.err
+    assert captured.out == ""


### PR DESCRIPTION
# feat(cli): add `calista db status`

## Summary
Adds `calista db status` to confirm database connectivity and report the current schema state for CALISTA. The command prints the backend, a password-hidden URL, and the Alembic revision (or “uninitialized”).

## Behavior
- Attempts a connection to the configured database.
- Prints backend and URL (password hidden).
- Reads Alembic state to report the current revision or “uninitialized”.
- Standardized error presentation (glyph + concise message).
- Clear handling for invalid/malformed database URLs.

## Scope
- **CLI**
  - New `status` subcommand under `calista db`.
  - Consistent error glyphs and messaging.
  - Scope DB guards to commands that actually touch the database.

## Tests
- Functional tests (Postgres) invoking `calista db status` for reachable and error paths, including schema reporting.
- Unit tests for message formatting and error display.

## Docs
- Installation guide updated to suggest checking connectivity via `calista db status`.

## Checklist
- [x] Command implemented
- [x] Postgres functional tests added and passing
- [x] Unit tests for messaging
- [x] Docs updated
