### PR TITLE
feat: introduce interfaces and bootstrap layers in accordance with ADR-0019

### DIFF
--- a/docs/dev/architecture/layered_architecture.md
+++ b/docs/dev/architecture/layered_architecture.md
@@ -1,0 +1,43 @@
+# Layered Architecture
+
+This page explains CALISTA’s layers, what belongs in each, and the import rules enforced in CI. It complements ADR-0018 (Hexagonal structure) and ADR-0019 (Interfaces + Bootstrap).
+
+`entrypoints → bootstrap → adapters → service_layer → interfaces → domain`
+
+## Principles
+
+- Depend **inward only** (outer layers may import inner layers; never the reverse).
+- **Adapters must not depend on service_layer or entrypoints.**
+- `interfaces/` is **independent** (no imports from `calista.*`).
+- Only **bootstrap** reads `calista.config` and injects values.
+
+## Responsibilities by layer
+
+- **entrypoints/** — CLI/UI. Talks only to **bootstrap**. No direct imports from adapters/service_layer/interfaces/domain.
+- **bootstrap/** — Composition root. Wires adapters to handlers, composes shared services (e.g., message bus, unit of work), reads config, may expose small facades.
+- **adapters/** — Concrete infrastructure. Implement **interfaces** (and, where applicable, domain repositories). Never import service_layer or entrypoints.
+- **service_layer/** — Application logic: commands/queries/handlers. Depends on **interfaces** and **domain** only.
+- **interfaces/** — Neutral contracts: protocols/ABCs and small DTOs shared by service_layer and adapters. No imports from `calista.*`.
+- **domain/** — Entities, domain services, domain repositories/ports. No imports from other app packages.
+
+## Import rules (matrix)
+
+Depend inward only; Import Linter enforces the following matrix.
+
+| From \ To         | entrypoints | bootstrap | adapters | service_layer | interfaces | domain |
+| ----------------- | :---------: | :-------: | :------: | :-----------: | :--------: | :----: |
+| **entrypoints**   |      —      |     ✅     |    ❌     |       ❌       |     ❌      |   ❌    |
+| **bootstrap**     |      ❌      |     —     |    ✅     |       ✅       |     ✅      |   ✅    |
+| **adapters**      |      ❌      |     ❌     |    —     |       ❌       |     ✅      |   ✅    |
+| **service_layer** |      ❌      |     ❌     |    ❌     |       —       |     ✅      |   ✅    |
+| **interfaces**    |      ❌      |     ❌     |    ❌     |       ❌       |     —      |   ❌    |
+| **domain**        |      ❌      |     ❌     |    ❌     |       ❌       |     ❌      |   —    |
+
+*Notes:*
+
+- If you need **type-only** names from `interfaces` in entrypoints, prefer documenting them in `bootstrap` or guard imports with `typing.TYPE_CHECKING`; keep the runtime rule as ❌.
+
+## References
+
+- ADR-0018 — Adopt Hexagonal (Ports & Adapters) Package Structure
+- ADR-0019 — Introduce `interfaces/` and `bootstrap/` Layers

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
           - Database CLI: user/cli/db.md
   - Developer Guide:
       - Overview: dev/index.md
+      - Architecture: dev/architecture/layered_architecture.md
       - Tooling: dev/tooling.md
       - Database:
           - "Migrations Policy": dev/db/migrations.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,37 +161,78 @@ tests_dir = ["tests/"]
 
 [tool.importlinter]
 root_package = "calista"
-# Optional:
-# include_external_packages = true
 exclude_type_checking_imports = true
 
 [[tool.importlinter.contracts]]
-id = "domain_pure"
-name = "Domain must not depend on outer layers"
-type = "forbidden"
-source_modules = ["calista.domain"]
-forbidden_modules = ["calista.adapters", "calista.entrypoints"]
+name = "Layered architecture"
+type = "layers"
+layers = [
+  "calista.entrypoints",
+  "calista.bootstrap",
+  "calista.adapters",
+  "calista.service_layer",
+  "calista.interfaces",
+  "calista.domain",
+]
 
+# 1) One-way layers (outer -> inner)
 [[tool.importlinter.contracts]]
-id = "service_no_entrypoints"
-name = "Service layer must not depend on entrypoints"
-type = "forbidden"
-source_modules = ["calista.service_layer"]
-forbidden_modules = ["calista.entrypoints"]
+id = "layers"
+name = "Layered architecture (outer to inner)"
+type = "layers"
+layers = [
+  "calista.entrypoints",
+  "calista.bootstrap",
+  "calista.adapters",
+  "calista.service_layer",
+  "calista.interfaces",
+  "calista.domain",
+]
 
+# 2) Entrypoints only talk to bootstrap (not adapters/service_layer/interfaces/domain)
 [[tool.importlinter.contracts]]
-id = "adapters_no_app_layers"
-name = "Adapters must not depend on service layer or entrypoints"
-type = "forbidden"
-source_modules = ["calista.adapters"]
-forbidden_modules = ["calista.service_layer", "calista.entrypoints"]
-
-[[tool.importlinter.contracts]]
-id = "entrypoints_no_adapters"
-name = "Entrypoints must not import adapters directly"
+id = "entrypoints_no_internals"
+name = "Entrypoints must not depend on application or inner layers"
 type = "forbidden"
 source_modules = ["calista.entrypoints"]
-forbidden_modules = ["calista.adapters"]
-ignore_imports = [
-  "calista.entrypoints.cli.db -> calista.adapters.db.engine",
-] # temporary until next PR
+forbidden_modules = [
+  "calista.adapters",
+  "calista.service_layer",
+  "calista.interfaces",
+  "calista.domain",
+]
+
+# 3) Adapters must not depend on service layer
+[[tool.importlinter.contracts]]
+id = "adapters_no_service_layer"
+name = "Adapters must not depend on service layer"
+type = "forbidden"
+source_modules = ["calista.adapters"]
+forbidden_modules = ["calista.service_layer"]
+
+# 4) Interfaces is a neutral boundary (no deps on app packages or domain)
+[[tool.importlinter.contracts]]
+id = "interfaces_independent"
+name = "Interfaces must not depend on application packages or domain"
+type = "forbidden"
+source_modules = ["calista.interfaces"]
+forbidden_modules = [
+  "calista.entrypoints",
+  "calista.bootstrap",
+  "calista.adapters",
+  "calista.service_layer",
+  "calista.domain",
+]
+
+[[tool.importlinter.contracts]]
+id = "only_bootstrap_reads_config"
+name = "Only bootstrap may import calista.config"
+type = "forbidden"
+source_modules = [
+  "calista.adapters",
+  "calista.service_layer",
+  "calista.interfaces",
+  "calista.domain",
+  "calista.entrypoints",
+]
+forbidden_modules = ["calista.config"]

--- a/src/calista/bootstrap/__init__.py
+++ b/src/calista/bootstrap/__init__.py
@@ -1,0 +1,17 @@
+"""Bootstrap (composition root) for CALISTA.
+
+Assembles the application at runtime: wires concrete adapters to service-layer
+handlers (queries/commands), composes shared services (e.g., message bus, unit
+of work), reads configuration, and may expose small facades for entrypoints
+(e.g., `bootstrap_queries()`).
+
+Import rules:
+- Entry points import *this* package (not adapters/service_layer/interfaces/domain).
+- This package may import: `calista.adapters`, `calista.service_layer`,
+  `calista.interfaces`, `calista.domain`, and `calista.config`.
+- Inner layers must not import `calista.bootstrap`.
+
+Public surface:
+- Re-export composition factories from this module; keep wiring helpers internal.
+- No business rules live here; this is assembly and lifecycle only.
+"""

--- a/src/calista/interfaces/__init__.py
+++ b/src/calista/interfaces/__init__.py
@@ -1,0 +1,10 @@
+"""Interfaces (application boundary) for CALISTA.
+
+Defines framework-free application contracts: protocols/ABCs and small DTOs
+shared by the service layer and adapters (e.g., providers/clients/buses,
+clocks, ID generators). Business rules stay out of this package.
+
+Dependency rule: this package is independent—do not import from any
+`calista.*` modules. It may be imported by `calista.service_layer`,
+`calista.adapters`, and `calista.bootstrap`.
+"""


### PR DESCRIPTION
# PR: Establish Interfaces & Bootstrap Layers with Enforced Boundaries

## Summary
This PR introduces the **interfaces** and **bootstrap** layers as first-class citizens in CALISTA’s architecture, and enforces the layered contracts with Import Linter. It also adds developer documentation explaining the rationale and usage.

## Highlights
- Defined `interfaces/` as the home for DTOs and service contracts, decoupling domain logic from adapters.
- Created `bootstrap/` to handle wiring and configuration access, separating setup from business code.
- Strengthened Import Linter rules to guard these boundaries, while allowing a temporary `entrypoints → adapters` ignore until the query façade lands.
- Added a “Layered Architecture” developer page, with an import matrix and links to ADR-0018/0019, making the design and rules visible to contributors.

## Why
This lays the foundation for stricter separation of concerns:  
- **Interfaces** clarify what the domain expects and exposes.  
- **Bootstrap** centralizes initialization logic.  
- **Import contracts** ensure discipline across layers.  
- **Documentation** makes the approach transparent for future maintainers.


