### PR TITLE
feat(utils): implement calista.utils namespace and import rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,7 +175,9 @@ layers = [
   "calista.service_layer",
   "calista.interfaces",
   "calista.domain",
+  "calista.utils",
 ]
+allow_indirect_imports = true
 
 # 2) Entrypoints only talk to bootstrap (not adapters/service_layer/interfaces/domain)
 [[tool.importlinter.contracts]]
@@ -188,6 +190,7 @@ forbidden_modules = [
   "calista.service_layer",
   "calista.interfaces",
   "calista.domain",
+  "calista.utils",
 ]
 allow_indirect_imports = true
 

--- a/src/calista/utils/__init__.py
+++ b/src/calista/utils/__init__.py
@@ -1,0 +1,28 @@
+"""Support namespace for cross-cutting, dependency-light helpers.
+
+This package provides a neutral location for small, reusable functions that
+would otherwise clutter feature packages. It is not a new architectural layer.
+
+Scope (ADR-0023):
+- Small, stateless helpers with minimal dependencies (e.g., sanitizing strings/URLs,
+  path utilities, trivial env parsing, slugification).
+- No business rules, no orchestration, no engines/handlers, no wiring.
+- Prefer pure functions; if I/O is unavoidable (e.g., reading an environment
+  variable), keep it shallow, opt-in, and easy to stub in tests.
+- Organize by single-purpose modules (e.g., ``sanitize.py``, ``paths.py``,
+  ``env.py``, ``slugify.py``) rather than one catch-all file.
+
+Import direction:
+- May be imported by any CALISTA package.
+- Must not import from application packages. Keep dependencies to the standard library
+  and only small, justified third-party utilities.
+
+Testing & usage:
+- Keep helpers deterministic and well-documented with focused unit tests.
+- Treat helpers as implementation details, not public API. If a helper starts
+  accumulating policy or coordination logic, promote it to a proper package.
+
+Public API:
+- Nothing is re-exported at the package level by default. Import specific
+  helpers from their defining modules to avoid incidental coupling.
+"""


### PR DESCRIPTION
# PR: feat(utils): implement calista.utils namespace and import rules

## Scope
This pull request introduces the new `calista.utils` support namespace and configures import‑linter to enforce its boundaries as defined in ADR‑0023.

## Motivation
Cross‑cutting helpers were previously scattered in feature packages, leading to leaky dependencies. ADR‑0023 established `calista.utils` as a neutral, dependency‑light home for such helpers.

## Changes
- Added `src/calista/utils/__init__.py` with module‑level docstring documenting scope and boundaries.
- Updated `pyproject.toml` import‑linter configuration:
  - Inserted `calista.utils` as the innermost leaf in the layered architecture.
