### PR TITLE
feat(redactor): implement regex-based sanitization for sensitive information in database URLs

### DIFF
--- a/src/calista/adapters/redactor.py
+++ b/src/calista/adapters/redactor.py
@@ -1,0 +1,94 @@
+"""Regex-based redactor for sanitizing secrets from strings.
+
+This module provides a Redactor implementation that masks sensitive values
+(passwords, tokens, API keys, etc.) found in database URLs, ODBC/DSN-style
+strings, HTTP Authorization headers, and free-form "key: value" fragments.
+It supports lenient and strict modes (strict also redacts usernames/ids).
+"""
+
+import re
+
+from calista.interfaces import redactor
+from calista.interfaces.redactor import RedactorMode
+
+# pylint: disable=too-few-public-methods
+
+PLACEHOLDER = "***"
+SECRET_KEYWORDS = [
+    "password",
+    "passwd",
+    "pwd",
+    "secret",
+    "token",
+    "api_key",
+    "apikey",
+    "access_token",
+    "refresh_token",
+    "id_token",
+    "authorization",
+    "sig",
+    "signature",
+]
+BEARER_PATTERN = re.compile(r"(?i)Bearer\s[0-9a-zA-Z\.]*")
+
+
+class Redactor(redactor.Redactor):
+    """Redactor implementation using regex-based sanitization."""
+
+    def __init__(self, mode: RedactorMode = RedactorMode.LENIENT) -> None:
+        self._mode = mode
+
+    def sanitize_db_url(self, raw_url: str) -> str:
+        sanitized = str(raw_url)
+
+        # 1) user:pass@  → user:***@
+        sanitized = re.sub(
+            r"(?<=://)([^:@/]+):([^@/]+)@",
+            r"\1:***@",
+            sanitized,
+        )
+
+        # 2) Strict: redact visible username before '@' (but only if one exists)
+        if self._mode == RedactorMode.STRICT:
+            sanitized = re.sub(
+                r"(?<=://)([^:@/]+)(?=:(?:\*\*\*|[^@/]*)@)",
+                PLACEHOLDER,
+                sanitized,
+            )
+
+        # 3) Bearer tokens: Bearer <token>
+        sanitized = BEARER_PATTERN.sub(PLACEHOLDER, sanitized)
+
+        # 4) Query-string secrets: build regex from SECRET_KEYWORDS
+
+        keywords_pattern = "|".join(
+            kw.replace("_", "[-_]?")
+            for kw in (
+                SECRET_KEYWORDS + ["user", "username", "uid"]
+                if self._mode == RedactorMode.STRICT
+                else SECRET_KEYWORDS
+            )
+        )
+        sanitized = re.sub(
+            rf"(?i)([?&](?:{keywords_pattern})=)[^&#\s;]*",
+            rf"\1{PLACEHOLDER}",
+            sanitized,
+        )
+
+        # 5) ODBC-ish pairs: Pwd=... (leave Uid alone unless strict)
+        sanitized = re.sub(r"(?i)\bPwd=\S+", f"Pwd={PLACEHOLDER}", sanitized)
+        if self._mode == RedactorMode.STRICT:
+            sanitized = re.sub(
+                r"(?i)\bUid=[^;]+",
+                f"Uid={PLACEHOLDER}",
+                sanitized,
+            )
+
+        # 6) Key:Value secrets (non-URL accidental forms)
+        sanitized = re.sub(
+            rf"(?i)(\b(?:{keywords_pattern})\s*:\s*)\S+",
+            rf"\1{PLACEHOLDER}",
+            sanitized,
+        )
+
+        return sanitized

--- a/src/calista/interfaces/redactor.py
+++ b/src/calista/interfaces/redactor.py
@@ -1,0 +1,40 @@
+"""Interfaces for redacting sensitive values.
+
+This module defines the Redactor interface and the RedactorMode enumeration
+used by adapters to sanitize secrets (passwords, tokens, API keys, etc.)
+from strings such as database URLs, HTTP authorization headers, and free-form
+key/value fragments. Implementations should provide sanitize_db_url that
+returns a display-safe string with sensitive values redacted.
+"""
+
+import abc
+from enum import Enum
+
+# pylint: disable=too-few-public-methods
+
+
+class RedactorMode(Enum):
+    """Enumeration for redactor modes.
+
+    Modes:
+    - LENIENT: redact passwords/tokens but keep usernames/ids visible.
+    - STRICT: redact passwords/tokens and also usernames/ids.
+    """
+
+    LENIENT = "lenient"
+    STRICT = "strict"
+
+
+class Redactor(abc.ABC):
+    """Interface for sanitizing sensitive information from strings."""
+
+    @abc.abstractmethod
+    def sanitize_db_url(self, raw_url: str) -> str:
+        """Return a display-safe DB URL.
+
+        Args:
+            raw_url: Raw database connection URL.
+
+        Returns:
+            A sanitized database URL with sensitive information redacted.
+        """

--- a/tests/unit/adapters/redactors/test_redactors.py
+++ b/tests/unit/adapters/redactors/test_redactors.py
@@ -1,0 +1,137 @@
+"""Unit tests for calista.adapters.redactor.Redactor.
+
+These tests verify that sensitive information (passwords, tokens, API keys,
+etc.) is redacted correctly from database URLs and plain strings. Each test
+case provides an input string and the expected outputs for non-strict and
+strict sanitization modes.
+"""
+
+import pytest
+
+from calista.adapters.redactor import Redactor
+from calista.interfaces.redactor import RedactorMode
+
+cases = [
+    (
+        "postgresql://alice:abc123@host/db",
+        "postgresql://alice:***@host/db",
+        "postgresql://***:***@host/db",
+    ),
+    (
+        "mysql+pymysql://alice:pass@localhost:3306/mydb",
+        "mysql+pymysql://alice:***@localhost:3306/mydb",
+        "mysql+pymysql://***:***@localhost:3306/mydb",
+    ),
+    (
+        "sqlite:///absolute/path/to/file.db",
+        "sqlite:///absolute/path/to/file.db",
+        "sqlite:///absolute/path/to/file.db",
+    ),
+    (
+        "postgresql://host/db?password=abc123&sslmode=require",
+        "postgresql://host/db?password=***&sslmode=require",
+        "postgresql://host/db?password=***&sslmode=require",
+    ),
+    (
+        "postgresql://host/db?user=foo&token=abc",
+        "postgresql://host/db?user=foo&token=***",
+        "postgresql://host/db?user=***&token=***",
+    ),
+    (
+        "postgresql://host/db?apikey=xyz&connect_timeout=10",
+        "postgresql://host/db?apikey=***&connect_timeout=10",
+        "postgresql://host/db?apikey=***&connect_timeout=10",
+    ),
+    (
+        "mysql://alice:abc123@host/db?access_token=abcd1234",
+        "mysql://alice:***@host/db?access_token=***",
+        "mysql://***:***@host/db?access_token=***",
+    ),
+    (
+        "postgresql://host/db?PaSsWoRd=secret",
+        "postgresql://host/db?PaSsWoRd=***",
+        "postgresql://host/db?PaSsWoRd=***",
+    ),
+    (
+        "postgresql://host/db?api-key=xyz",
+        "postgresql://host/db?api-key=***",
+        "postgresql://host/db?api-key=***",
+    ),
+    (
+        "Server=myServer;Database=myDB;Uid=alice;Pwd=myPass;",
+        "Server=myServer;Database=myDB;Uid=alice;Pwd=***",
+        "Server=myServer;Database=myDB;Uid=***;Pwd=***",
+    ),
+    (
+        "Driver={SQL Server};Server=serverName;Database=myDB;Uid=Bob;Pwd=myPass;",
+        "Driver={SQL Server};Server=serverName;Database=myDB;Uid=Bob;Pwd=***",
+        "Driver={SQL Server};Server=serverName;Database=myDB;Uid=***;Pwd=***",
+    ),
+    ("password: abc", "password: ***", "password: ***"),
+    ("pwd: 12345", "pwd: ***", "pwd: ***"),
+    ("token: xyz123", "token: ***", "token: ***"),
+    ("api_key: abc123", "api_key: ***", "api_key: ***"),
+    (
+        "password: abc token: def api_key: ghi username: alice",
+        "password: *** token: *** api_key: *** username: alice",
+        "password: *** token: *** api_key: *** username: ***",
+    ),
+    (
+        "secret: foo passwd: bar pwd: baz uid: alice123",
+        "secret: *** passwd: *** pwd: *** uid: alice123",
+        "secret: *** passwd: *** pwd: *** uid: ***",
+    ),
+    ("not a url", "not a url", "not a url"),
+    (
+        "postgresql://alice:@host/db",
+        "postgresql://alice:@host/db",
+        "postgresql://***:@host/db",
+    ),
+    (
+        "http://example.com?authorization=Bearer X.Y.Z",
+        "http://example.com?authorization=***",
+        "http://example.com?authorization=***",
+    ),
+    ("bareword", "bareword", "bareword"),
+]
+
+
+@pytest.mark.parametrize(
+    "case",
+    cases,
+    ids=[c[0] for c in cases],
+)
+def test_safe_db_url(case):
+    """Verify safe_db_url redacts sensitive information.
+
+    Each parametrized `case` is a tuple of:
+        (input_string, expected_non_strict, expected_strict)
+
+    The test asserts that safe_db_url produces the expected redacted string
+    when called with strict=False and strict=True.
+    """
+    input_url, expected_non_strict, expected_strict = case
+
+    non_strict_redactor = Redactor(mode=RedactorMode.LENIENT)
+    non_strict_result = non_strict_redactor.sanitize_db_url(input_url)
+    non_strict_msg = (
+        "\nExpected\n    "
+        f"{expected_non_strict}\n"
+        "but got\n    "
+        f"{non_strict_result}\n"
+        "for input\n    "
+        f"{input_url}"
+    )
+    assert non_strict_result == expected_non_strict, non_strict_msg
+
+    strict_redactor = Redactor(mode=RedactorMode.STRICT)
+    strict_result = strict_redactor.sanitize_db_url(input_url)
+    strict_msg = (
+        "\nExpected\n    "
+        f"{expected_strict}\n"
+        "but got\n    "
+        f"{strict_result}\n"
+        "for input\n    "
+        f"{input_url}"
+    )
+    assert strict_result == expected_strict, strict_msg


### PR DESCRIPTION
## Summary

Add a new Redactor adapter and interface for redacting sensitive values in database URLs and other strings.

## Changes

- Implemented Redactor class with sanitize_db_url method using regex to redact passwords, tokens, etc.
- Added RedactorMode for lenient and strict redaction modes.
- Added comprehensive unit tests covering various input cases.
