### PR TITLE
reafactor(filestore): move FileStore interface from adapters to the interface layer

### DIFF
--- a/src/calista/adapters/filestore/memory.py
+++ b/src/calista/adapters/filestore/memory.py
@@ -59,10 +59,10 @@ import hashlib
 import io
 import threading
 
-from .interface import (
-    AbstractFileStore,
+from ...interfaces.filestore import (
     AbstractWriter,
     BlobStat,
+    FileStore,
     IntegrityError,
     NotFound,
 )
@@ -70,7 +70,7 @@ from .interface import (
 __all__ = ["MemoryFileStore"]
 
 
-class MemoryFileStore(AbstractFileStore):
+class MemoryFileStore(FileStore):
     """In-memory Content-Addressed Store (CAS) backend.
 
     Stores immutable blobs **entirely in RAM** and addresses them by their

--- a/src/calista/interfaces/filestore.py
+++ b/src/calista/interfaces/filestore.py
@@ -160,7 +160,7 @@ class AbstractWriter(abc.ABC):
             self.close()
 
 
-class AbstractFileStore(abc.ABC):
+class FileStore(abc.ABC):
     """Pure CAS interface.
 
     Identity is the digest; blobs are immutable.

--- a/tests/contract/filestore/conftest.py
+++ b/tests/contract/filestore/conftest.py
@@ -21,11 +21,11 @@ import pytest
 from calista.adapters.filestore.memory import MemoryFileStore
 
 if TYPE_CHECKING:
-    from calista.adapters.filestore.interface import AbstractFileStore
+    from calista.interfaces.filestore import FileStore
 
 
 @pytest.fixture(params=["memory"])
-def store(request: pytest.FixtureRequest) -> AbstractFileStore:
+def store(request: pytest.FixtureRequest) -> FileStore:
     """Return a fresh filestore instance for the requested backend.
 
     Current params:

--- a/tests/contract/filestore/test_filestore_concurrency.py
+++ b/tests/contract/filestore/test_filestore_concurrency.py
@@ -14,10 +14,10 @@ from threading import Barrier, BrokenBarrierError, Event
 
 import pytest
 
-from calista.adapters.filestore.interface import AbstractFileStore
+from calista.interfaces.filestore import FileStore
 
 
-def test_concurrent_commit_dedup(store: AbstractFileStore, arbitrary_bytes: bytes):
+def test_concurrent_commit_dedup(store: FileStore, arbitrary_bytes: bytes):
     """Concurrent writers committing identical bytes deduplicate to one object.
 
     Setup:

--- a/tests/contract/filestore/test_filestore_large.py
+++ b/tests/contract/filestore/test_filestore_large.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 if TYPE_CHECKING:
-    from calista.adapters.filestore.interface import AbstractFileStore
+    from calista.interfaces.filestore import FileStore
 
 # Payload sizes (~5 MiB and ~20 MiB)
 SIZES = [5 * 1024 * 1024, 20 * 1024 * 1024]
@@ -44,7 +44,7 @@ def _pattern_bytes(n: int) -> bytes:
 
 @pytest.mark.slow
 @pytest.mark.parametrize("size", SIZES)
-def test_large_blob_put_bytes_and_stream_read(store: AbstractFileStore, size: int):
+def test_large_blob_put_bytes_and_stream_read(store: FileStore, size: int):
     """Ingest a large payload via `put_bytes` and verify streamed reads.
 
     - Confirms the returned digest equals the SHA-256 of the data.
@@ -73,7 +73,7 @@ def test_large_blob_put_bytes_and_stream_read(store: AbstractFileStore, size: in
 @pytest.mark.parametrize("size", SIZES)
 @pytest.mark.parametrize("put_chunk", PUT_CHUNKS)
 def test_large_blob_put_path_and_put_stream_variants(
-    store: AbstractFileStore, tmp_path: Path, size: int, put_chunk: int
+    store: FileStore, tmp_path: Path, size: int, put_chunk: int
 ):
     """Ingest large payloads via `put_path` and `put_stream` with odd chunk sizes.
 

--- a/tests/contract/filestore/test_filestore_paths_streams.py
+++ b/tests/contract/filestore/test_filestore_paths_streams.py
@@ -15,11 +15,11 @@ from pathlib import Path
 
 import pytest
 
-from calista.adapters.filestore.interface import AbstractFileStore
+from calista.interfaces.filestore import FileStore
 
 
 def test_put_path_and_symlink_policy(
-    store: AbstractFileStore, tmp_path: Path, arbitrary_bytes: bytes
+    store: FileStore, tmp_path: Path, arbitrary_bytes: bytes
 ):
     """`put_path` accepts regular files, refuses symlinks by default, and allows
     them only with `follow_symlinks=True`."""
@@ -41,7 +41,7 @@ def test_put_path_and_symlink_policy(
 
 
 def test_put_path_chunking_and_str_path(
-    store: AbstractFileStore, tmp_path: Path, arbitrary_bytes: bytes
+    store: FileStore, tmp_path: Path, arbitrary_bytes: bytes
 ):
     """`put_path` honors custom chunk sizes and accepts both `Path` and `str`."""
     p = tmp_path / "chunk.bin"
@@ -53,7 +53,7 @@ def test_put_path_chunking_and_str_path(
 
 
 def test_put_path_unicode_and_expected_digest(
-    store: AbstractFileStore, tmp_path: Path, arbitrary_bytes: bytes
+    store: FileStore, tmp_path: Path, arbitrary_bytes: bytes
 ):
     """`put_path` handles Unicode/spacey paths and respects `expected_digest`."""
     p = tmp_path / "dir with spaces" / "unicodé_📄.bin"
@@ -66,7 +66,7 @@ def test_put_path_unicode_and_expected_digest(
     assert guarded.digest == expected
 
 
-def test_put_stream_keeps_stream_open(store: AbstractFileStore, arbitrary_bytes: bytes):
+def test_put_stream_keeps_stream_open(store: FileStore, arbitrary_bytes: bytes):
     """`put_stream` must consume the stream to EOF but not close it."""
     bio = io.BytesIO(arbitrary_bytes)
     info = store.put_stream(bio, chunk_size=7)
@@ -74,9 +74,7 @@ def test_put_stream_keeps_stream_open(store: AbstractFileStore, arbitrary_bytes:
     assert store.exists(info.digest)
 
 
-def test_open_read_is_streamlike_and_seek(
-    store: AbstractFileStore, arbitrary_bytes: bytes
-):
+def test_open_read_is_streamlike_and_seek(store: FileStore, arbitrary_bytes: bytes):
     """`open_read` returns a file-like stream where `read(0)` is a no-op; if
     seekable, `seek` + `read` returns the expected slice.
     """

--- a/tests/unit/adapters/filestore/test_filestore_props.py
+++ b/tests/unit/adapters/filestore/test_filestore_props.py
@@ -26,8 +26,8 @@ import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
-from calista.adapters.filestore.interface import AbstractFileStore, IntegrityError
 from calista.adapters.filestore.memory import MemoryFileStore
+from calista.interfaces.filestore import FileStore, IntegrityError
 
 pytestmark = [pytest.mark.property]
 
@@ -81,7 +81,7 @@ def chunk_by_sizes(b: bytes, sizes: list[int]) -> list[bytes]:
 def store_factory():
     """Factory that returns a **fresh** filestore instance per Hypothesis example."""
 
-    def make() -> AbstractFileStore:
+    def make() -> FileStore:
         # Add other backends when added
         return MemoryFileStore()
 
@@ -104,7 +104,7 @@ _PROPSET = settings(max_examples=50, deadline=None)
     chunk=st.integers(min_value=1, max_value=16_384),
 )
 def test_digest_stability_across_methods(
-    store_factory: Callable[[], AbstractFileStore], data: bytes, chunk: int
+    store_factory: Callable[[], FileStore], data: bytes, chunk: int
 ):
     """Same bytes → same digest across all ingest methods and chunkings."""
     store = store_factory()
@@ -132,7 +132,7 @@ def test_digest_stability_across_methods(
     sizes=st.lists(st.integers(min_value=0, max_value=8_192), min_size=0, max_size=20),
 )
 def test_writer_chunk_partition_invariance(
-    store_factory: Callable[[], AbstractFileStore], data: bytes, sizes: list[int]
+    store_factory: Callable[[], FileStore], data: bytes, sizes: list[int]
 ):
     """Writing any partition of chunks yields the same digest as writing once."""
     store = store_factory()
@@ -151,7 +151,7 @@ def test_writer_chunk_partition_invariance(
 @_PROPSET
 @given(data=st.binary(min_size=0, max_size=64_000))
 def test_expected_digest_guard_property(
-    store_factory: Callable[[], AbstractFileStore], data: bytes
+    store_factory: Callable[[], FileStore], data: bytes
 ):
     """Integrity guard accepts exact match and rejects a one-nibble mismatch."""
     store = store_factory()
@@ -181,7 +181,7 @@ def test_expected_digest_guard_property(
 @_PROPSET
 @given(data=st.binary(min_size=0, max_size=64_000))
 def test_exists_and_stat_consistency(
-    store_factory: Callable[[], AbstractFileStore], data: bytes
+    store_factory: Callable[[], FileStore], data: bytes
 ):
     """After ingest, `exists()` is true and `stat()` metadata matches digest/size."""
     store = store_factory()

--- a/tests/unit/adapters/filestore/test_memory_store.py
+++ b/tests/unit/adapters/filestore/test_memory_store.py
@@ -19,8 +19,8 @@ from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
-from calista.adapters.filestore.interface import IntegrityError, NotFound
 from calista.adapters.filestore.memory import MemoryFileStore
+from calista.interfaces.filestore import IntegrityError, NotFound
 
 ## Adjust pylint to deal with fixtures
 # pylint: disable=redefined-outer-name


### PR DESCRIPTION
## Summary

Move the abstract FileStore class from the adapter layer to the interfaces layer in accordance with ADR-0019.