### PR TITLE
feat(uow): implement SQLAlchemy-backed Unit of Work with commit and rollback methods

### DIFF
--- a/src/calista/adapters/unit_of_work.py
+++ b/src/calista/adapters/unit_of_work.py
@@ -1,0 +1,38 @@
+"""SQLAlchemy-backed Unit of Work for Calista.
+
+Provides a context-managed UnitOfWork using a SQLAlchemy Connection
+and the SqlAlchemyEventStore.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from calista.adapters.eventstore.sqlalchemy import SqlAlchemyEventStore
+from calista.interfaces.unit_of_work import AbstractUnitOfWork
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Connection, Engine
+
+
+class SqlAlchemyUnitOfWork(AbstractUnitOfWork):
+    """SQLAlchemy-backed Unit of Work."""
+
+    def __init__(self, engine: Engine):
+        self.engine = engine
+        self.connection: Connection
+
+    def __enter__(self):
+        self.connection = self.engine.connect()
+        self.eventstore = SqlAlchemyEventStore(self.connection)
+        return super().__enter__()
+
+    def __exit__(self, *args):
+        super().__exit__(*args)
+        self.connection.close()
+
+    def commit(self):
+        self.connection.commit()
+
+    def rollback(self):
+        self.connection.rollback()

--- a/src/calista/interfaces/unit_of_work.py
+++ b/src/calista/interfaces/unit_of_work.py
@@ -1,0 +1,39 @@
+"""Unit of Work interface for Calista.
+
+Defines the AbstractUnitOfWork contract: a context-managed unit of work
+with an EventStore and abstract commit/rollback methods.
+"""
+
+from __future__ import annotations
+
+import abc
+
+from .eventstore import EventStore
+
+
+class AbstractUnitOfWork(abc.ABC):
+    """Contract for a transactional unit of work."""
+
+    eventstore: EventStore
+
+    def __enter__(self) -> AbstractUnitOfWork:
+        """Enter the unit of work context and return the unit.
+
+        Implementations may acquire transactional resources here.
+        """
+        return self
+
+    def __exit__(self, *args):
+        """Exit the unit of work context.
+
+        Default behavior is to roll back on exit.
+        """
+        self.rollback()
+
+    @abc.abstractmethod
+    def commit(self):
+        """Persist changes and finalize the transaction."""
+
+    @abc.abstractmethod
+    def rollback(self):
+        """Revert changes and clean up transactional resources."""

--- a/tests/integration/adapters/uow/test_uow.py
+++ b/tests/integration/adapters/uow/test_uow.py
@@ -1,0 +1,58 @@
+"""Integration tests for the SQLAlchemy-backed Unit of Work adapter.
+
+Verifies commit and rollback behavior of SqlAlchemyUnitOfWork.
+"""
+
+import pytest
+
+from calista.adapters.unit_of_work import SqlAlchemyUnitOfWork
+from calista.interfaces.eventstore import EventEnvelope
+
+
+def test_uow_can_add_event(sqlite_engine_memory, make_event):
+    """Unit of Work can add an event to the event store."""
+    uow = SqlAlchemyUnitOfWork(sqlite_engine_memory)
+    event = EventEnvelope(**make_event())
+    with uow:
+        persisted_event = uow.eventstore.append([event])[0]
+        uow.commit()
+
+    # Verify the event was added
+    with uow:
+        events = list(uow.eventstore.read_since())
+
+    assert events[0] == persisted_event
+
+
+def test_uow_rollback_discards_event(sqlite_engine_memory, make_event):
+    """Unit of Work rollback discards uncommitted events."""
+    uow = SqlAlchemyUnitOfWork(sqlite_engine_memory)
+    event = EventEnvelope(**make_event())
+    with uow:
+        uow.eventstore.append([event])
+        # Intentionally not calling commit()
+
+    # Verify the event was not added
+    with uow:
+        events = list(uow.eventstore.read_since())
+
+    assert len(events) == 0
+
+
+def test_rolls_back_on_error(sqlite_engine_memory, make_event):
+    """Ensure an exception inside the UnitOfWork context triggers a rollback."""
+
+    class MyException(Exception):
+        """Custom exception for testing."""
+
+    event = EventEnvelope(**make_event())
+    uow = SqlAlchemyUnitOfWork(sqlite_engine_memory)
+    with pytest.raises(MyException):
+        with uow:
+            uow.eventstore.append([event])
+            raise MyException()
+
+    # new connection to verify rollback
+    with uow:
+        events = list(uow.eventstore.read_since())
+    assert len(events) == 0


### PR DESCRIPTION
# adapters: add SQLAlchemy-backed Unit of Work + interface

## Summary
Introduce a minimal **Unit of Work (UoW)** abstraction and a SQLAlchemy-based implementation. The UoW exposes an `eventstore` bound to a transactional SQLAlchemy `Connection`, with context-managed **commit/rollback** semantics.


## What’s in this PR
### New interface
- `src/calista/interfaces/unit_of_work.py`
  - `AbstractUnitOfWork` (context manager)
    - `eventstore: EventStore`
    - `commit()` / `rollback()` (abstract)
    - Default `__exit__` rolls back (safety-first).

### New adapter
- `src/calista/adapters/unit_of_work.py`
  - `SqlAlchemyUnitOfWork(engine: Engine)`
    - On `__enter__`: opens `Connection`, wires `SqlAlchemyEventStore(connection)`, returns `self`.
    - On `__exit__`: rolls back via base class, then **closes** the connection.
    - `commit()` ⇒ `connection.commit()`
    - `rollback()` ⇒ `connection.rollback()`

### Tests
- `tests/integration/adapters/uow/test_uow.py`
  - `test_uow_can_add_event`: appends and commits; subsequent read sees the event.
  - `test_uow_rollback_discards_event`: no commit; subsequent read sees **no** events.
  - `test_rolls_back_on_error`: exception inside context ⇒ automatic rollback confirmed.

## Design notes
- Default rollback in `__exit__` prevents accidental writes (“explicit commit or it didn’t happen”).
