### PR TITLE
refactor(eventstore): replace magic number with `ULID_LENGTH` constant

### DIFF
--- a/src/calista/interfaces/eventstore.py
+++ b/src/calista/interfaces/eventstore.py
@@ -54,6 +54,8 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any
 
+ULID_LENGTH = 26  # Enforced in EventEnvelope and DB schema
+
 # --- Exceptions to standardize adapter behavior ---
 
 
@@ -104,7 +106,7 @@ class EventEnvelope:
     global_seq: int | None = None  # Assigned by the event store
 
     def __post_init__(self) -> None:
-        if len(self.event_id) != 26:
+        if len(self.event_id) != ULID_LENGTH:
             raise InvalidEnvelopeError("event_id must be a 26-character ULID.")
         if self.version < 1:
             raise InvalidEnvelopeError("version must be >= 1")


### PR DESCRIPTION
# PR: refactor(eventstore): replace magic number with `ULID_LENGTH` constant

### Summary

Introduces a `ULID_LENGTH` constant in `interfaces.eventstore` to replace the hard-coded check for `event_id` length.

### Changes

* Add `ULID_LENGTH = 26` with inline note referencing `EventEnvelope` and DB schema.
* Update `EventEnvelope.__post_init__` to validate `event_id` length against the constant.

### Impact

No behavior change; improves clarity and maintainability by removing a magic number.
