### PR TITLE
feat(filestore): introduce new CAS-only filestore interface and LocalFileStore backend

### DIFF
--- a/src/calista/adapters/filestore/local.py
+++ b/src/calista/adapters/filestore/local.py
@@ -1,0 +1,95 @@
+"""Local filesystem-based CAS file store adapter."""
+
+import hashlib
+import os
+import tempfile
+from pathlib import Path
+from typing import BinaryIO
+
+from calista.interfaces.filestore import BlobStats, FileStore, PathLike
+
+SHA256_LENGTH = 64
+CHUNK_SIZE = 1024 * 1024
+
+
+class LocalFileStore(FileStore):
+    """CAS FileStore implementation that uses the local filesystem."""
+
+    def __init__(self, root: PathLike) -> None:
+        self._root = Path(root)
+        self._root.mkdir(parents=True, exist_ok=True)
+
+    # --- Core Operations ---
+
+    def store(self, fileobj: BinaryIO) -> BlobStats:
+        hasher = hashlib.sha256()
+        size = 0
+
+        # disable mutmut because it likes to replace False with None,
+        # which is falsy and thus equivalent here
+        with tempfile.NamedTemporaryFile(dir=self._root, delete=False) as tmp:  # pragma: no mutate # fmt: skip # pylint:disable=line-too-long
+            tmp_path = Path(tmp.name)
+
+            for chunk in iter(lambda: fileobj.read(CHUNK_SIZE), b""):
+                hasher.update(chunk)
+                tmp.write(chunk)
+                size += len(chunk)
+
+        sha256 = hasher.hexdigest()
+        dest = self._determine_cas_path(sha256)
+
+        # If blob already exists: use it, delete temp
+        if dest.exists():
+            tmp_path.unlink()
+            return BlobStats(size_bytes=size, sha256=sha256)
+
+        # Otherwise atomic move
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        os.replace(tmp_path, dest)
+
+        return BlobStats(size_bytes=size, sha256=sha256)
+
+    def open_read(self, sha256: str) -> BinaryIO:
+        path = self._determine_cas_path(sha256)
+
+        try:
+            return path.open("rb")
+        except FileNotFoundError:
+            raise FileNotFoundError(f"Blob {sha256!r} not found") from None
+
+    # --- Convenience Methods ---
+
+    def exists(self, sha256: str) -> bool:
+        path = self._determine_cas_path(sha256)
+        return path.is_file()
+
+    # --- Internal Helpers ---
+
+    def _determine_cas_path(self, sha256: str) -> Path:
+        """Determine the filesystem path for a given SHA-256 key.
+
+        Sharded directory structure: root/aa/bb/aabbccddeeff...
+        """
+        self._validate_sha256(sha256)
+        return self._root / sha256[0:2] / sha256[2:4] / sha256
+
+    @staticmethod
+    def _validate_sha256(sha256: str) -> None:
+        """Raise ValueError if the provided SHA-256 key is invalid.
+
+        Enforced:
+        - No slashes
+        - Exact length of 64 characters
+        - Hexadecimal characters only
+        """
+
+        if "/" in sha256 or "\\" in sha256:  # pylint: disable=magic-value-comparison
+            raise ValueError("Invalid CAS key")
+
+        if len(sha256) != SHA256_LENGTH:
+            raise ValueError("Invalid CAS key length (expected 64 characters)")
+
+        try:
+            int(sha256, 16)
+        except ValueError as e:
+            raise ValueError("SHA-256 key contains non-hex characters") from e

--- a/src/calista/interfaces/filestore.py
+++ b/src/calista/interfaces/filestore.py
@@ -1,0 +1,76 @@
+"""File store interface definitions."""
+
+import abc
+import os
+from dataclasses import dataclass
+from typing import BinaryIO
+
+PathLike = str | os.PathLike[str]
+
+
+@dataclass
+class BlobStats:
+    """Class representing the metadata of a blob."""
+
+    size_bytes: int
+    sha256: str
+
+
+class FileStore(abc.ABC):
+    """Abstract base class for CAS file storage operations."""
+
+    # --- Core Operations ---
+
+    @abc.abstractmethod
+    def store(self, fileobj: BinaryIO) -> BlobStats:
+        """Store bytes from a binary file-like object in the CAS filestore.
+
+        The filestore reads from the stream's *current position* until EOF.
+        Callers are responsible for seeking to the desired position, typically 0.
+
+        Args:
+            fileobj (BinaryIO): A binary file-like object to read data from.
+
+        Returns:
+            BlobStats: Metadata about the stored blob.
+
+        Note:
+            If a file with the same SHA-256 hash already exists in the filestore,
+            it will not be duplicated. Instead, the metadata of the existing
+            file will be returned.
+        """
+
+    @abc.abstractmethod
+    def open_read(self, sha256: str) -> BinaryIO:
+        """Open a file from the file store for reading in binary mode.
+
+        Args:
+            sha256 (str): The content-addressable storage key of the file (SHA-256).
+
+        Returns:
+            BinaryIO: A binary file-like object for reading the blob.
+
+        Raises:
+            FileNotFoundError: If the file does not exist in the filestore.
+            ValueError: If the provided SHA-256 key is invalid.
+
+        Example:
+            with file_store.open_read(sha256) as f:
+                data = f.read()
+        """
+
+    # --- Convenience Methods ---
+
+    @abc.abstractmethod
+    def exists(self, sha256: str) -> bool:
+        """Check if a file exists in the file store.
+
+        Args:
+            sha256 (str): The content-addressable storage key of the file (SHA-256).
+
+        Raises:
+            ValueError: If the provided SHA-256 key is invalid.
+
+        Returns:
+            bool: True if the file exists, False otherwise.
+        """

--- a/tests/contract/filestore/test_filestore.py
+++ b/tests/contract/filestore/test_filestore.py
@@ -2,7 +2,7 @@
 
 These tests ensure that any filestore implementation adheres to the expected
 behavior defined by the filestore interface. These tests do not depend on
-specific implementations, backend, filesystem, or storage technology,but
+specific implementations, backend, filesystem, or storage technology, but
 rather validate the contract that all implementations must fulfill.
 """
 
@@ -35,7 +35,7 @@ def filestore(request: pytest.FixtureRequest, tmp_path) -> Iterable[FileStore]:
     construct the corresponding backend. Each invocation yields a brand-new
     store instance for isolation.
     """
-    # Select filstore based on param
+    # Select filestore based on param
     match request.param:
         case "local":
             root = tmp_path / "filestore"

--- a/tests/contract/filestore/test_filestore.py
+++ b/tests/contract/filestore/test_filestore.py
@@ -1,0 +1,137 @@
+"""Contract tests for filestore implementations.
+
+These tests ensure that any filestore implementation adheres to the expected
+behavior defined by the filestore interface. These tests do not depend on
+specific implementations, backend, filesystem, or storage technology,but
+rather validate the contract that all implementations must fulfill.
+"""
+
+import hashlib
+import io
+from collections.abc import Iterable
+
+import pytest
+
+from calista.adapters.filestore.local import LocalFileStore
+from calista.interfaces.filestore import BlobStats, FileStore
+
+# ============================================================================
+#                               Fixtures
+# ============================================================================
+
+# pylint: disable=redefined-outer-name
+
+NONEXISTENT = "0" * 64  # "SHA-256" that should not exist in any filestore
+
+
+@pytest.fixture(params=["local"])
+def filestore(request: pytest.FixtureRequest, tmp_path) -> Iterable[FileStore]:
+    """Return a fresh filestore instance for the requested backend.
+
+    Current params:
+      - `"local"` → `LocalFileStore` (local filesystem)
+
+    Extend by adding new identifiers to `params` and branching below to
+    construct the corresponding backend. Each invocation yields a brand-new
+    store instance for isolation.
+    """
+    # Select filstore based on param
+    match request.param:
+        case "local":
+            root = tmp_path / "filestore"
+            yield LocalFileStore(root=root)
+        case _:
+            raise ValueError(f"unknown filestore type: {request.param}")
+
+
+def test_store_and_open_read_roundtrip(filestore: FileStore):
+    """Test that storing and then reading bytes returns the original data."""
+    data = b"hello"
+    stats = filestore.store(io.BytesIO(data))
+
+    assert isinstance(stats, BlobStats)
+
+    with filestore.open_read(stats.sha256) as f:
+        assert f.read() == data
+
+
+def test_store_reads_from_current_position(filestore: FileStore):
+    """Test that storing from a stream reads from the current position."""
+    buffer = io.BytesIO(b"0123456789")
+    buffer.seek(3)
+
+    stats = filestore.store(buffer)
+
+    expected = b"3456789"
+    assert stats.size_bytes == len(expected)
+    assert stats.sha256 == hashlib.sha256(expected).hexdigest()
+
+    with filestore.open_read(stats.sha256) as f:
+        assert f.read() == expected
+
+
+def test_exists_reports_correct_existence(filestore: FileStore):
+    """Test that exists() reports correct existence of blobs."""
+    data = b"existence test"
+    stats = filestore.store(io.BytesIO(data))
+
+    assert filestore.exists(stats.sha256) is True
+    assert filestore.exists(NONEXISTENT) is False
+
+
+def test_open_read_raises_for_nonexistent_file(filestore: FileStore):
+    """Test that open_read raises FileNotFoundError for nonexistent blobs."""
+    with pytest.raises(FileNotFoundError) as exc_info:
+        filestore.open_read(NONEXISTENT)
+
+    assert exc_info.value.args[0] == f"Blob {NONEXISTENT!r} not found"
+
+
+@pytest.mark.parametrize(
+    "invalid_sha, error_msg",
+    [
+        ("/invalid", "Invalid CAS key"),
+        ("\\invalid", "Invalid CAS key"),
+        ("short", "Invalid CAS key length (expected 64 characters)"),
+        ("0" * 65, "Invalid CAS key length (expected 64 characters)"),
+        ("0" * 62 + ":a", "SHA-256 key contains non-hex characters"),
+    ],
+    ids=["slashes", "double-slashes", "too-short", "too-long", "non-hex"],
+)
+def test_open_read_raises_for_invalid_sha256(
+    filestore: FileStore, invalid_sha, error_msg
+):
+    """Test that open_read raises ValueError for invalid SHA-256 keys."""
+    with pytest.raises(ValueError) as exc_info:
+        filestore.open_read(invalid_sha)
+
+    assert exc_info.value.args[0] == error_msg
+
+
+@pytest.mark.parametrize(
+    "invalid_sha, error_msg",
+    [
+        ("/invalid", "Invalid CAS key"),
+        ("\\invalid", "Invalid CAS key"),
+        ("short", "Invalid CAS key length (expected 64 characters)"),
+        ("0" * 65, "Invalid CAS key length (expected 64 characters)"),
+        ("0" * 62 + ":a", "SHA-256 key contains non-hex characters"),
+    ],
+    ids=["slashes", "double-slashes", "too-short", "too-long", "non-hex"],
+)
+def test_exists_raises_for_invalid_sha256(filestore: FileStore, invalid_sha, error_msg):
+    """Test that exists raises ValueError for invalid SHA-256 keys."""
+    with pytest.raises(ValueError) as exc_info:
+        filestore.exists(invalid_sha)
+    assert exc_info.value.args[0] == error_msg
+
+
+def test_store_deduplicates_identical_files(filestore: FileStore):
+    """Test that storing identical files results in the same BlobStats."""
+    data = b"duplicate me"
+
+    stats1 = filestore.store(io.BytesIO(data))
+    stats2 = filestore.store(io.BytesIO(data))
+
+    assert stats1.sha256 == stats2.sha256
+    assert stats1.size_bytes == stats2.size_bytes

--- a/tests/integration/adapters/filestore/test_local_filestore.py
+++ b/tests/integration/adapters/filestore/test_local_filestore.py
@@ -1,0 +1,204 @@
+"""Integration tests for the LocalFileStore adapter.
+
+This module contains integration tests that validate the LocalFileStore's behavior
+with the local filesystem. The LocalFileStore should also pass the contract tests defined
+in `tests/contract/filestore/test_filestore.py`. These are additional tests specific to
+the LocalFileStore implementation.
+"""
+
+import hashlib
+import io
+import tempfile
+from pathlib import Path
+
+from calista.adapters.filestore.local import CHUNK_SIZE, LocalFileStore
+
+
+def _get_root(filestore):
+    return filestore._root  # pylint: disable=protected-access
+
+
+def test_local_filestore_initialization(tmp_path):
+    """Test that LocalFileStore initializes correctly with a given root path."""
+    root = tmp_path / "filestore_root"
+    root.mkdir(parents=True, exist_ok=True)
+    store = LocalFileStore(root=root)
+    assert _get_root(store).exists()
+    assert _get_root(store).is_dir()
+
+
+def test_local_filestore_creates_root_if_missing(tmp_path):
+    """Test that LocalFileStore creates the root directory if it does not exist."""
+    top_level_dir = tmp_path / "top_level_dir"
+    top_level_dir.mkdir(parents=True, exist_ok=True)
+    root_path = top_level_dir / "calista" / "new_filestore_root"
+    assert not root_path.exists()
+
+    LocalFileStore(root=root_path)
+    assert root_path.exists()
+    assert root_path.is_dir()
+
+
+def test_local_filestore_stores_file_correctly(tmp_path):
+    """Test that LocalFileStore stores a file and returns correct BlobStats."""
+
+    root = tmp_path / "filestore"
+    root.mkdir(parents=True, exist_ok=True)
+    filestore = LocalFileStore(root=root)
+
+    data = b"sample data for testing"
+    stats = filestore.store(io.BytesIO(data))
+
+    assert stats.size_bytes == len(data)
+    assert stats.sha256 == hashlib.sha256(data).hexdigest()
+
+    # Verify that the file exists in the filestore
+    assert filestore.exists(stats.sha256)
+
+    # Verify that the stored file can be read back correctly
+    with filestore.open_read(stats.sha256) as f:
+        read_data = f.read()
+    assert read_data == data
+
+    # Verify the file is stored at the correct path
+    expected_path = filestore._determine_cas_path(stats.sha256)  # pylint: disable=protected-access
+    assert expected_path.exists()
+    assert expected_path.is_file()
+    with expected_path.open("rb") as f:
+        stored_data = f.read()
+    assert stored_data == data
+
+
+def test_local_filestore_sharding(tmp_path):
+    """Test that LocalFileStore correctly shards files into subdirectories."""
+
+    root = tmp_path / "filestore"
+    root.mkdir(parents=True, exist_ok=True)
+    filestore = LocalFileStore(root=root)
+    data = b"another sample data for sharding test"
+    stats = filestore.store(io.BytesIO(data))
+
+    # Determine expected shard path
+    sha256 = stats.sha256
+    shard_dir_a = sha256[:2]
+    shard_dir_b = sha256[2:4]
+    expected_path = _get_root(filestore) / shard_dir_a / shard_dir_b / sha256
+
+    assert expected_path.exists()
+    assert expected_path.is_file()
+
+
+def test_store_uses_root_for_temp_files(monkeypatch, tmp_path):
+    """Test that LocalFileStore uses the correct root directory for temporary files."""
+
+    root = tmp_path / "filestore"
+
+    # Grab original before patching
+    orig_named_tempfile = tempfile.NamedTemporaryFile
+
+    store = LocalFileStore(root)
+
+    captured: dict[str, Path | None] = {}
+
+    def fake_named_tempfile(*, dir=None, delete=False):  # pylint: disable=redefined-builtin
+        # record what LocalFileStore passed
+        captured["dir"] = dir
+        # delegate to the real function (only with the args we care about)
+        return orig_named_tempfile(dir=root, delete=delete)
+
+    monkeypatch.setattr(
+        "calista.adapters.filestore.local.tempfile.NamedTemporaryFile",
+        fake_named_tempfile,
+    )
+
+    store.store(io.BytesIO(b"data"))
+
+    assert captured["dir"] == root
+
+
+def test_temp_file_deleted_on_existing_blob(tmp_path):
+    """Test that temporary files are deleted if the blob already exists."""
+
+    root = tmp_path / "filestore"
+    root.mkdir(parents=True, exist_ok=True)
+    filestore = LocalFileStore(root=root)
+    data = b"data that will be stored"
+    stats = filestore.store(io.BytesIO(data))
+
+    # Store the same data again
+    stats2 = filestore.store(io.BytesIO(data))
+
+    assert stats2.sha256 == stats.sha256
+    assert stats2.size_bytes == stats.size_bytes
+
+    # Verify that no temporary files remain in the filestore root
+    root_path = _get_root(filestore)
+    temp_files = list(root_path.glob("tmp*"))
+    assert len(temp_files) == 0
+
+
+def test_store_reports_total_size_across_chunks(tmp_path):
+    """Test that LocalFileStore.store reports the correct total size for large files."""
+
+    root = tmp_path / "filestore"
+    store = LocalFileStore(root)
+
+    # Force at least 2 chunks
+    data = b"x" * (CHUNK_SIZE * 2 + 10)
+
+    stats = store.store(io.BytesIO(data))
+
+    assert stats.size_bytes == len(data)
+
+
+def test_store_reads_in_bounded_chunks(tmp_path):
+    """Test that LocalFileStore reads input streams in bounded chunks."""
+
+    class LoggingStream(io.BytesIO):
+        """BytesIO that logs the size argument of each read call."""
+
+        def __init__(self, data: bytes):
+            super().__init__(data)
+            self.calls: list[int | None] = []
+
+        def read(self, size: int | None = -1) -> bytes:
+            self.calls.append(size)
+            if size is None:
+                size = -1
+            return super().read(size)
+
+    root = tmp_path / "filestore"
+    store = LocalFileStore(root)
+
+    data = b"x" * (2 * CHUNK_SIZE + 10)
+    stream = LoggingStream(data)
+
+    store.store(stream)
+
+    # All but possibly the last read should use CHUNK_SIZE
+    assert all((n == CHUNK_SIZE) for n in stream.calls[:-1])
+    # And we must never pass None as the size
+    assert None not in stream.calls
+
+
+def test_store_is_idempotent_for_existing_parent_dir(tmp_path, monkeypatch):
+    """Test that LocalFileStore.store is idempotent when parent directories exist."""
+
+    root = tmp_path / "filestore"
+    store = LocalFileStore(root)
+
+    # Force all blobs to live under the same parent directory
+    def fake_determine_cas_path(self: LocalFileStore, sha256: str) -> Path:
+        return self._root / "aa" / "bb" / sha256  # pylint: disable=protected-access
+
+    monkeypatch.setattr(
+        LocalFileStore,
+        "_determine_cas_path",
+        fake_determine_cas_path,
+    )
+
+    # First store creates the parent dirs
+    store.store(io.BytesIO(b"first blob"))
+
+    # Second store should NOT crash even though parent dir exists
+    store.store(io.BytesIO(b"second blob"))


### PR DESCRIPTION
### **Title**

feat(filestore): introduce new CAS-only filestore interface and LocalFileStore backend

### **Summary**

This PR replaces the previous filestore design with the revised CAS-only model described in **ADR-0025** (revision of ADR-0024). The filestore now provides a minimal, content-addressed API and no longer performs path-based ingestion or export.

### **Changes**

* Add `FileStore` interface with the reduced CAS surface:

  * `store(stream)`
  * `open_read(sha256)`
  * `exists(sha256)`
* Add `BlobStats` value object.
* Implement `LocalFileStore`:

  * sharded layout (`aa/bb/<sha256>`)
  * atomic installation via temporary file + `os.replace`
  * SHA-256 validation and deduplication
  * bounded chunked reads (`CHUNK_SIZE`)
* Add filestore contract tests covering required interface behavior.
* Add integration tests for LocalFileStore:

  * initialization and root creation
  * chunked reads and total-size reporting
  * temp file placement under the filestore root
  * deduplication
  * parent-directory idempotency
  * sharding structure

### **Notes**

* This PR reflects the architectural shift away from path-based `put` and `export`; those responsibilities move to ingestion/export services outside the CAS layer.

